### PR TITLE
Fixes astro-compress options

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,5 +5,5 @@ import { defineConfig } from 'astro/config'
 // https://astro.build/config
 export default defineConfig({
   site: 'https://astro-multiverse.netlify.app',
-  integrations: [Critters(), Compress({ svg: false })],
+  integrations: [Critters(), Compress({ SVG: false })],
 })


### PR DESCRIPTION
In newer versions of astro-compress the compress options have been pascal cased. This fixes it.