### PR TITLE
Fix React diagnostics and SSR hydration in Gallery

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "oxlint": "^1.69.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "sharp": "^0.35.1",
     "tailwindcss": "^4.3.1"
+  },
+  "devDependencies": {
+    "sharp": "0.35.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,12 +38,13 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
-      sharp:
-        specifier: ^0.35.1
-        version: 0.35.1
       tailwindcss:
         specifier: ^4.3.1
         version: 4.3.1
+    devDependencies:
+      sharp:
+        specifier: 0.35.1
+        version: 0.35.1
 
 packages:
 

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState, useEffectEvent } from "react";
+import React, { useEffect, useRef, useState, useCallback, useSyncExternalStore } from "react";
 import { createPortal } from "react-dom";
 
 interface ImageData {
@@ -121,11 +121,15 @@ const Lightbox: React.FC<LightboxProps> = ({
 const Gallery: React.FC<GalleryProps> = ({ images }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [currentIndex, setCurrentIndex] = useState(0);
-  const [isMounted, setIsMounted] = useState(false);
   const [loading, setLoading] = useState(false);
 
+  const isMounted = useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false,
+  );
+
   useEffect(() => {
-    setIsMounted(true);
     const timer = setTimeout(() => {
       document.body.classList.remove("is-preload");
     }, 100);
@@ -144,32 +148,34 @@ const Gallery: React.FC<GalleryProps> = ({ images }) => {
     document.body.classList.remove("modal-active");
   };
 
-  const onNavigateNext = useEffectEvent((e?: React.MouseEvent | KeyboardEvent) => {
-    if (e && "stopPropagation" in e) e.stopPropagation();
-    setCurrentIndex((prev) => (prev + 1) % images.length);
-    setLoading(true);
-  });
+  const onNavigateNext = useCallback(
+    (e?: React.MouseEvent | KeyboardEvent) => {
+      if (e && "stopPropagation" in e) e.stopPropagation();
+      setCurrentIndex((prev) => (prev + 1) % images.length);
+      setLoading(true);
+    },
+    [images.length],
+  );
 
-  const onNavigatePrev = useEffectEvent((e?: React.MouseEvent | KeyboardEvent) => {
-    if (e && "stopPropagation" in e) e.stopPropagation();
-    setCurrentIndex((prev) => (prev - 1 + images.length) % images.length);
-    setLoading(true);
-  });
-
-  const onClose = useEffectEvent(() => {
-    closeLightbox();
-  });
+  const onNavigatePrev = useCallback(
+    (e?: React.MouseEvent | KeyboardEvent) => {
+      if (e && "stopPropagation" in e) e.stopPropagation();
+      setCurrentIndex((prev) => (prev - 1 + images.length) % images.length);
+      setLoading(true);
+    },
+    [images.length],
+  );
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (!isOpen) return;
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") closeLightbox();
       if (e.key === "ArrowRight") onNavigateNext(e);
       if (e.key === "ArrowLeft") onNavigatePrev(e);
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen]);
+  }, [isOpen, onNavigateNext, onNavigatePrev]);
 
   return (
     <>


### PR DESCRIPTION
This PR resolves React Hook errors and SSR hydration warnings in the Gallery component. Key changes include refactoring useEffectEvent to useCallback for prop-safe navigation functions, using useSyncExternalStore for isMounted checks, and moving sharp to devDependencies. Verified with oxlint, oxfmt, and Playwright.

---
*PR created automatically by Jules for task [13989056052721704444](https://jules.google.com/task/13989056052721704444) started by @torn4dom4n*